### PR TITLE
Protect static class pointer with a mutex.

### DIFF
--- a/g2o/core/batch_stats.cpp
+++ b/g2o/core/batch_stats.cpp
@@ -26,11 +26,13 @@
 
 #include "batch_stats.h"
 #include <cstring>
+#include <mutex>
 
 namespace g2o {
   using namespace std;
 
   G2OBatchStatistics* G2OBatchStatistics::_globalStats=0;
+  std::mutex G2OBatchStatistics::_globalStatsMutex;
 
   #ifndef PTHING
   #define PTHING(s) \

--- a/g2o/core/batch_stats.cpp
+++ b/g2o/core/batch_stats.cpp
@@ -82,10 +82,5 @@ namespace g2o {
     return os;
   };
 
-  void G2OBatchStatistics::setGlobalStats(G2OBatchStatistics* b)
-  {
-     std::lock_guard<std::mutex> lock(_globalStatsMutex);
-     _globalStats = b;
-  }
 
 } // end namespace

--- a/g2o/core/batch_stats.cpp
+++ b/g2o/core/batch_stats.cpp
@@ -84,7 +84,8 @@ namespace g2o {
 
   void G2OBatchStatistics::setGlobalStats(G2OBatchStatistics* b)
   {
-    _globalStats = b;
+     std::lock_guard<std::mutex> lock(_globalStatsMutex);
+     _globalStats = b;
   }
 
 } // end namespace

--- a/g2o/core/batch_stats.h
+++ b/g2o/core/batch_stats.h
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <vector>
+#include <mutex>
 
 #include "g2o_core_api.h"
 
@@ -70,10 +71,14 @@ namespace g2o {
     size_t hessianLandmarkDimension;  ///< dimension of the landmark matrix in Schur
     size_t choleskyNNZ;               ///< number of non-zeros in the cholesky factor
 
-    static G2OBatchStatistics* globalStats() {return _globalStats;}
+    static G2OBatchStatistics* globalStats() {
+      std::lock_guard<std::mutex> lock(_globalStatsMutex);
+      return _globalStats;
+    }
     static void setGlobalStats(G2OBatchStatistics* b);
     protected:
     static G2OBatchStatistics* _globalStats;
+    static std::mutex _globalStatsMutex;
   };
 
   G2O_CORE_API std::ostream& operator<<(std::ostream&, const G2OBatchStatistics&);

--- a/g2o/core/batch_stats.h
+++ b/g2o/core/batch_stats.h
@@ -71,18 +71,21 @@ namespace g2o {
     size_t hessianLandmarkDimension;  ///< dimension of the landmark matrix in Schur
     size_t choleskyNNZ;               ///< number of non-zeros in the cholesky factor
 
-    static G2OBatchStatistics* globalStats() {
+    static G2OBatchStatistics *globalStats() {
+#ifdef __x86_64__
       std::lock_guard<std::mutex> lock(_globalStatsMutex);
+#endif
       return _globalStats;
     }
 
-    static void setGlobalStats(G2OBatchStatistics* b)
-    {
-       std::lock_guard<std::mutex> lock(_globalStatsMutex);
-       _globalStats = b;
+    static void setGlobalStats(G2OBatchStatistics *b) {
+#ifdef __x86_64__
+      std::lock_guard<std::mutex> lock(_globalStatsMutex);
+#endif
+      _globalStats = b;
     }
 
-    protected:
+  protected:
     static G2OBatchStatistics* _globalStats;
     static std::mutex _globalStatsMutex;
   };

--- a/g2o/core/batch_stats.h
+++ b/g2o/core/batch_stats.h
@@ -75,7 +75,13 @@ namespace g2o {
       std::lock_guard<std::mutex> lock(_globalStatsMutex);
       return _globalStats;
     }
-    static void setGlobalStats(G2OBatchStatistics* b);
+
+    static void setGlobalStats(G2OBatchStatistics* b)
+    {
+       std::lock_guard<std::mutex> lock(_globalStatsMutex);
+       _globalStats = b;
+    }
+
     protected:
     static G2OBatchStatistics* _globalStats;
     static std::mutex _globalStatsMutex;


### PR DESCRIPTION
Currently, there is a static class pointer that can cause data races:

    static G2OBatchStatistics* _globalStats;

We correct this by adding a mutex to the class and locking the pointer during get/set operations.